### PR TITLE
fix: tenantIds in user objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [1.17.2] - 2023-10-04
+
+### Fixes
+- Added `tenantIds` to the user objects returned by signIn, SignUp, signInUp and consumeCode APIs
+
 ## [1.17.1] - 2023-08-31
 
 ### Changed

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -2202,8 +2202,12 @@ components:
             userId:
               type: string
               example: rq238mrq2389rvq123213
-            
-        
+        tenantIds:
+          type: array
+          items:
+            type: string
+            example: public
+
     user:
       type: object
       properties:
@@ -2215,6 +2219,11 @@ components:
         timeJoined:
           type: number
           example: 1638433545183
+        tenantIds:
+          type: array
+          items:
+            type: string
+            example: public
 
     email:
       type: string
@@ -2246,6 +2255,11 @@ components:
         timeJoined:
           type: number
           example: 1638433545183
+        tenantIds:
+          type: array
+          items:
+            type: string
+            example: public
     
     thirdPartyId:
       type: string


### PR DESCRIPTION
Added `tenantIds` to the user objects returned by signIn, SignUp, signInUp and consumeCode APIs