### PR TITLE
fix: formfields should be camelcase for /{apiBasePath}/<tenantId>/user/password/reset

### DIFF
--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1172,7 +1172,7 @@ paths:
               properties:
                 method:
                   $ref: '#/components/schemas/method'
-                formfields:
+                formFields:
                   $ref: '#/components/schemas/formFields'
                 token:
                   $ref: '#/components/schemas/token'


### PR DESCRIPTION
This broke codegen when generating from version FDI 1.19.0 on swaggerhub (target of typescript-fetch). However, it appears it breaks in all of the codegens when you use the API directly (verified in 3.0.0 as well). 

This was tested with core 9.0.2 and supertokens-node 17 / 18. It appears the code that reads this field has not changed though, as its identical in the latest version (see https://github.com/supertokens/supertokens-node/blob/master/lib/build/recipe/emailpassword/api/passwordReset.js#L37).

Basically, codegen would forward this as `formfields` instead of `formFields`, which in turn caused the `validateFormFieldsOrThrowError` as `requestBody.formFields` would be undefined.

I am unsure if these are codegened from something else, if it is let me know and I will open a PR in the proper location.